### PR TITLE
Add buildroot "board"

### DIFF
--- a/boards/buildroot.json
+++ b/boards/buildroot.json
@@ -1,0 +1,15 @@
+{
+  "build": {
+    "core": "FIXMECORE",
+    "extra_flags": "-DPORTDUINO_BUILDROOT",
+    "variant": "buildroot"
+  },
+  "upload": {
+    "maximum_ram_size": 99999999,
+    "maximum_size": 99999999
+  },
+  "frameworks": ["arduino"],
+  "name": "Portduino",
+  "url": "https://github.com/meshtastic/framework-portduino",
+  "vendor": "Meshtastic, LLC"
+}


### PR DESCRIPTION
Adds support for building meshtasticd with external toolchains by passing environment variables.

Utilized by buildroot and openwrt meshtastic packaging projects.