### PR TITLE
Update framework-portduino version in platform.json

### DIFF
--- a/platform.json
+++ b/platform.json
@@ -15,7 +15,7 @@
   "packages": {
     "framework-portduino": {
       "type": "framework",
-      "version": "https://github.com/meshtastic/framework-portduino.git#45b678b04bad232d58788a8ac801672811cd18a1",
+      "version": "https://github.com/meshtastic/framework-portduino.git#447329159e67d19cefc9f47b799bc0fa0f51c010",
       "optional": true
     }
   },


### PR DESCRIPTION
## Summary

Bumps the `framework-portduino` git ref from `45b678b` to `4473291` (the merge of [meshtastic/framework-portduino#68](https://github.com/meshtastic/framework-portduino/pull/68)) so this platform picks up the WiFi submodule's `extern "C"` / `logging.h` fix in `WiFiServer.cpp`.

## What's in the bump

`4473291` — "Bump libraries/WiFi to pick up extern \"C\" / logging.h fix" (framework-portduino#68). Single submodule pointer change: `c75a5e8` → `467ec17` in `libraries/WiFi`. That submodule commit ([meshtastic/WiFi#5](https://github.com/meshtastic/WiFi/pull/5)) moves `#include "logging.h"` out of `WiFiServer.cpp`'s `extern "C" { ... }` block so `arduino::log(...)` keeps C++ linkage and doesn't collide with libc's `extern "C" double log(double)` from `<math.h>` under Apple Clang.

## Context

Hit while bringing up the macOS-native portduino build — see firmware PR meshtastic/firmware#10300.

## Downstream chain

- ✅ [meshtastic/WiFi#5](https://github.com/meshtastic/WiFi/pull/5) — fix the file in the submodule (merged).
- ✅ [meshtastic/framework-portduino#68](https://github.com/meshtastic/framework-portduino/pull/68) — bump the submodule pointer (merged).
- **(this PR)** — bump the framework-portduino git ref.
- meshtastic/firmware#10300 — drop \`bin/patch-framework-portduino-darwin.py\` and its \`extra_scripts\` entry, then bump \`portduino_base.platform\` to this PR's merge SHA.

## Test plan

- [x] No-op on Linux: pure pin bump; the framework-side change is preprocessor-order only.
- [x] Verified equivalent transformation builds `meshtasticd` cleanly on macOS arm64 — the firmware-side pre-build patcher applies the same reordering and the resulting binary boots in SimRadio mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)