### PR TITLE
Bump framework-portduino to drop accept() log spam

### DIFF
--- a/platform.json
+++ b/platform.json
@@ -15,7 +15,7 @@
   "packages": {
     "framework-portduino": {
       "type": "framework",
-      "version": "https://github.com/meshtastic/framework-portduino.git#447329159e67d19cefc9f47b799bc0fa0f51c010",
+      "version": "https://github.com/meshtastic/framework-portduino.git#214bf605c02c2c26d2fb963132c4bce77f416d81",
       "optional": true
     }
   },


### PR DESCRIPTION
## Summary

Bumps the `framework-portduino` git ref in `platform.json` to pull in [meshtastic/framework-portduino#69](https://github.com/meshtastic/framework-portduino/pull/69), which itself bumps `libraries/WiFi` to [meshtastic/WiFi#6](https://github.com/meshtastic/WiFi/pull/6) — removing two verbose `log(SysWifi, LogVerbose, ...)` calls in `WiFiServer::available()` that were firing on every poll of the accept loop.

`meshtasticd` polls that path hundreds of times per second, so the daemon was flooding stdout with:

```
calling accept
accept=0
calling accept
accept=0
...
```

## Why these were noisy despite `LogVerbose`

`framework-portduino`'s `cores/portduino/logging.cpp::logv()` ignores its `level` argument and unconditionally writes to `Serial`, so `LogVerbose` is just as loud as `LogInfo`. The chain of upstream PRs fixes the immediate noise problem surgically; making `logv()` level-aware would be a wider behavioral change (every other `LogVerbose` site across the framework would suddenly go silent), so it's left as a separate follow-up.

## Diff

```diff
-      "version": "https://github.com/meshtastic/framework-portduino.git#447329159e67d19cefc9f47b799bc0fa0f51c010",
+      "version": "https://github.com/meshtastic/framework-portduino.git#214bf605c02c2c26d2fb963132c4bce77f416d81",
```

`214bf60` is the merge commit of `meshtastic/framework-portduino#69` on `meshtastic/framework-portduino` master.

## Test plan

- [x] meshtastic/WiFi#6 merged (commit `92b0641`)
- [x] meshtastic/framework-portduino#69 merged (commit `214bf60`)
- [x] Built `native-macos` `meshtasticd` against this branch — clean compile
- [x] Verified `meshtasticd -s` is silent during idle accept polling

🤖 Generated with [Claude Code](https://claude.com/claude-code)